### PR TITLE
pyzorsocket: do not check if message body is empty

### DIFF
--- a/pyzor/pyzorsocket/pyzorsocket.py
+++ b/pyzor/pyzorsocket/pyzorsocket.py
@@ -23,7 +23,9 @@ class RequestHandler(StreamRequestHandler):
         msg = parser.parse(self.rfile)
 
         digest = pyzor.digest.DataDigester(msg).value
-        check = pyzor.client.Client().check(digest)
+        # whitelist 'default' digest (all messages with empty/short bodies)
+        if digest != 'da39a3ee5e6b4b0d3255bfef95601890afd80709':
+            check = pyzor.client.Client().check(digest)
 
         self.write_json({k: v for k, v in check.items()})
 


### PR DESCRIPTION
emails without body content but Attachements/Subjects
(billings, pdfs from suppliers, etc) all have the
same digest (da39a3ee5e6b4b0d3255bfef95601890afd80709)
which pyzor matches.